### PR TITLE
Cronjob Label "reindexieren" nennen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -5,7 +5,7 @@ search_it_readme = Readme
 
 search_it_info = Such Addon
 search_it_infotext = Such Addon
-search_it_reindex = Re-indizieren
+search_it_reindex = Search it: Reindexieren
 
 search_it_settings_mode = Suchmodus
 search_it_settings_result = Suchergebnis


### PR DESCRIPTION
Das ist die korrekte Duden-Bezeichnung für den Vorgang (auch, wenn ich selbst hin und wieder fälschlicherweise indizieren geschrieben habe).

Außerdem präfixt YFeed bspw. seinen Cronjob-Namen.